### PR TITLE
[REFACTOR] 앱 서비스 새로고침 시 initAuth가 2번 발생하는 현상 해결

### DIFF
--- a/app/(main)/mypage/posts/Table.tsx
+++ b/app/(main)/mypage/posts/Table.tsx
@@ -41,7 +41,7 @@ export default function Table({ posts }: { posts: MyPostItem[] }) {
                   {post.title}
                 </Link>
                 <span className="text-xs text-primitive-green w-fit">
-                  {`(${post.likeCount})`}
+                  {`(${post.commentCount})`}
                 </span>
               </div>
             </td>

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactNode, useState, useEffect } from 'react';
+import { ReactNode, useState, useEffect, useRef } from 'react';
 import { useAuthStore } from '@/lib/store/authStore';
 
 // ReactQuery Provider
@@ -28,13 +28,18 @@ export default function Providers({ children }: { children: ReactNode }) {
   // 인증 상태 초기화 여부
   const [isAuthReady, setIsAuthReady] = useState(false);
 
+  const didInitRef = useRef(false);
+
   useEffect(() => {
+    if (didInitRef.current) return; // 이미 실행했으면 바로 return
+    didInitRef.current = true;
+
     const init = async () => {
       await initAuth();
       setIsAuthReady(true);
     };
     init();
-  }, [isAuthReady, initAuth]);
+  }, []); // 빈 배열 = 마운트 시 한 번만 실행
 
   if (!isAuthReady) {
     return null;

--- a/components/posts/list/PostList.tsx
+++ b/components/posts/list/PostList.tsx
@@ -40,7 +40,7 @@ export default function PostList({
         />
       </div>
 
-      <div className="border border-primitive-graySecond rounded-lg overflow-hidden">
+      <div className="border border-primitive-graySecond rounded-lg">
         <table className="table-fixed w-full border-collapse text-center ">
           <caption className="sr-only">게시글 목록</caption>
           <colgroup>

--- a/query/like/useLikeMutations.ts
+++ b/query/like/useLikeMutations.ts
@@ -14,8 +14,8 @@ export function useLikeMutation() {
       likeType: 'like' | 'dislike';
     }) => likePost(postId, likeType),
     onSuccess: (data, variables) => {
-      queryClient.invalidateQueries({ queryKey: ['like', variables.postId] });
-      // queryClient.setQueryData(['like', variables.postId], data);
+      // queryClient.invalidateQueries({ queryKey: ['like', variables.postId] });
+      queryClient.setQueryData(['like', variables.postId], data);
     },
     onError: (error) => {
       console.error('like mutation error:', error);


### PR DESCRIPTION


## #️⃣연관된 이슈

> 

  <br/>

## ✔️PR Checklist

- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

<br/>

## 🔎 작업 내용
### 앱 서비스 새로고침 시 initAuth가 2번 발생하는 현상 해결
- provider.tsx > useEffect의 의존성 배열안에 참조값이 들어가있어서 그랬음. 그래서 그 값들을 빼고, useEffect 함수를 마운트 시 딱 한번만 실행되게 -> 의존성 배열 비움.
- React 18 StrictMode (개발 모드) 에서 useEffect 안의 코드를 2번 실행시키기 때문에, useRef를 써서 한번만 실행되게 함
