### PR TITLE
[REFACTOR] 글 수정 시 미디어 diff 처리 및 에디터에 data-media-id 스키마 추가

### DIFF
--- a/components/posts/write/PostWriteForm.tsx
+++ b/components/posts/write/PostWriteForm.tsx
@@ -129,6 +129,7 @@ export default function PostWriteForm({
         title,
         content: processedHtml,
       };
+      console.log('postPayload', postPayload);
 
       // 2. edit이면 mediaDiff (html 내 미디어 파일 변경 정보) 추가
       if (mode === 'edit') {
@@ -139,7 +140,7 @@ export default function PostWriteForm({
 
         const mediaPayload = buildEditMediaPayload(
           initialData?.content || '',
-          processedHtml,
+          html,
         );
 
         postPayload = {

--- a/components/posts/write/utils/mediaDiff.ts
+++ b/components/posts/write/utils/mediaDiff.ts
@@ -1,20 +1,42 @@
-import { collectMediaIdsAndOrdersFromHtml } from './imageProcessor';
+import {
+  collectMediaIdsAndOrdersFromHtml,
+  collectNewMediaOrdersFromHtml,
+} from './imageProcessor';
 
 export function buildEditMediaPayload(initialHtml: string, finalHtml: string) {
   const initial = collectMediaIdsAndOrdersFromHtml(initialHtml);
   const final = collectMediaIdsAndOrdersFromHtml(finalHtml);
+  console.log('finalHtml==============================', finalHtml);
 
   const deletedMediaIds = initial
-    .filter((i) => !final.some((f) => f.mediaId === i.mediaId))
-    .map((i) => i.mediaId);
+    .filter(
+      ({ mediaId: initialMediaId }) =>
+        !final.some(
+          ({ mediaId: finalMediaId }) =>
+            Number(finalMediaId) === Number(initialMediaId),
+        ),
+    )
+    .map(({ mediaId: initialMediaId }) => initialMediaId);
 
-  const newMediaOrders = final
-    .filter((f) => !initial.some((i) => i.mediaId === f.mediaId))
-    .map((f) => f.order);
+  const newMediaOrders = collectNewMediaOrdersFromHtml(finalHtml);
 
-  const oldMediaIdsAndOrders = initial.filter((i) =>
-    final.some((f) => f.mediaId === i.mediaId),
+  const oldMediaIdsAndOrdersArray = initial.filter(
+    ({ mediaId: initialMediaId }) =>
+      final.some(
+        ({ mediaId: finalMediaId }) =>
+          Number(finalMediaId) === Number(initialMediaId),
+      ),
   );
+  const oldMediaIdsAndOrders: Record<string, number> = {};
+  oldMediaIdsAndOrdersArray.forEach(({ mediaId, order }) => {
+    oldMediaIdsAndOrders[mediaId] = order;
+  });
+
+  console.log('initial', initial);
+  console.log('final', final);
+  console.log('deletedMediaIds', deletedMediaIds);
+  console.log('newMediaOrders', newMediaOrders);
+  console.log('oldMediaIdsAndOrders', oldMediaIdsAndOrders);
 
   return {
     oldMediaIdsAndOrders,

--- a/components/tiptap/tiptap-node/image-node/image-extension.ts
+++ b/components/tiptap/tiptap-node/image-node/image-extension.ts
@@ -1,0 +1,23 @@
+import { Image as BaseImage } from '@tiptap/extension-image';
+
+/**
+ * Image 노드에 data-media-id 속성 추가.
+ * 글 수정 시 기존 미디어 유지/삭제 diff용으로 사용.
+ */
+export const Image = BaseImage.extend({
+  addAttributes() {
+    return {
+      ...this.parent?.() ?? {},
+      dataMediaId: {
+        default: null,
+        parseHTML: (element) => element.getAttribute('data-media-id'),
+        renderHTML: (attributes) =>
+          attributes.dataMediaId
+            ? { 'data-media-id': attributes.dataMediaId }
+            : {},
+      },
+    };
+  },
+});
+
+export default Image;

--- a/components/tiptap/tiptap-node/video-node/video-extension.ts
+++ b/components/tiptap/tiptap-node/video-node/video-extension.ts
@@ -33,6 +33,14 @@ export const Video = Node.create<VideoOptions>({
       controls: {
         default: true,
       },
+      dataMediaId: {
+        default: null,
+        parseHTML: (element) => element.getAttribute('data-media-id'),
+        renderHTML: (attributes) =>
+          attributes.dataMediaId
+            ? { 'data-media-id': attributes.dataMediaId }
+            : {},
+      },
     };
   },
 


### PR DESCRIPTION


## #️⃣연관된 이슈

>

  <br/>

## ✔️PR Checklist

- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

<br/>

## 🔎 작업 내용

- TipTap Image/Video 노드에 data-media-id 속성 추가 (파싱·직렬화 유지)
- 수정 시 미디어 유지/삭제/추가 구분: oldMediaIdsAndOrders, deletedMediaIds, newMediaOrders
- 새 미디어만 newMediaOrders에 포함 (blob 또는 placeholder 기준, 에디터 내 복붙 제외)
- 붙여넣기 시 data-media-id 제거해 복붙 시 기존 mediaId가 따라오지 않도록 처리
- 미디어 태그 수집 시 문서 순서 유지 (querySelectorAll('img, video'))