### PR TITLE
[REFACTOR] STOMP WebSocket 연결 구조 개선 및 onConnect 이벤트 리스너 패턴 도입

### DIFF
--- a/components/chat/ChatWrap.tsx
+++ b/components/chat/ChatWrap.tsx
@@ -4,16 +4,25 @@ import { getStompClient } from '@/lib/socket/client';
 import ChatPanel from './ChatPanel';
 import UserPanel from './UserPanel';
 import { useEffect } from 'react';
+import { useAuthStore } from '@/lib/store/authStore';
+import { useRouter } from 'next/navigation';
 
 export default function ChatWrap() {
+  const router = useRouter();
+  const accessToken = useAuthStore((state) => state.accessToken);
+
   // 마운트 시점에 websocket 연결
   useEffect(() => {
-    const client = getStompClient();
-
+    if (!accessToken) {
+      alert('로그인 후 이용해주세요.');
+      router.replace('/login');
+      return;
+    }
+    const client = getStompClient(); // websocket 연결
     return () => {
-      client.deactivate(); // 페이지 나가면(언마운트 시) websocket 연결 해제 (disconnect)
+      client.deactivate(); // 페이지 나가거나, 토큰 변경 시 websocket 연결 해제 (disconnect)
     };
-  }, []);
+  }, [accessToken]);
 
   return (
     <div className="mt-4 flex gap-3 h-130">

--- a/hooks/chat/useChatMessages.ts
+++ b/hooks/chat/useChatMessages.ts
@@ -1,26 +1,16 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { getStompClient } from '@/lib/socket/client';
 import type { ReceiveChatMessageResponse } from '@/types/socket/chat';
+import { useStompSubscription } from './useStompSubscription';
 
 // 채팅 메시지 hook
 export const useChatMessages = () => {
   // 채팅 메시지 상태
   const [messages, setMessages] = useState<ReceiveChatMessageResponse[]>([]);
 
-  // 채팅 메시지 수신 subscribe 사이드 이펙트
-  useEffect(() => {
-    const client = getStompClient();
-
-    client.onConnect = () => {
-      const subscription = client.subscribe('/sub/chat/message', (message) => {
-        const newMessage = JSON.parse(message.body);
-
-        setMessages((prev) => [...prev, newMessage]);
-      });
-
-      return () => subscription.unsubscribe();
-    };
-  }, []);
+  useStompSubscription('/sub/chat/message', (message) => {
+    setMessages((prev) => [...prev, message]);
+  });
 
   // 채팅 메시지 전송 행동 함수
   const sendMessage = (chat: string) => {

--- a/hooks/chat/useChatUsers.ts
+++ b/hooks/chat/useChatUsers.ts
@@ -1,26 +1,15 @@
-import { useEffect, useState } from 'react';
-import { getStompClient } from '@/lib/socket/client';
+import { useState } from 'react';
 import type { ChatUserInfo } from '@/types/socket/chat';
+import { useStompSubscription } from './useStompSubscription';
 
 // 접속자 목록 hook
 export const useChatUsers = () => {
   // 접속자 목록 상태
   const [users, setUsers] = useState<ChatUserInfo[] | null>(null);
 
-  // 접속자 목록 수신 subscribe
-  useEffect(() => {
-    const client = getStompClient();
-
-    client.onConnect = () => {
-      const subscription = client.subscribe('/sub/chat/users', (message) => {
-        const newUsers = JSON.parse(message.body);
-
-        setUsers(newUsers.users);
-      });
-
-      return () => subscription.unsubscribe();
-    };
-  }, []);
+  useStompSubscription('/sub/chat/users', (message) => {
+    setUsers(message.users);
+  });
 
   return {
     users,

--- a/hooks/chat/useStompSubscription.ts
+++ b/hooks/chat/useStompSubscription.ts
@@ -1,0 +1,39 @@
+import {
+  addOnConnectListener,
+  getStompClient,
+  removeOnConnectListener,
+} from '@/lib/socket/client';
+import { StompSubscription } from '@stomp/stompjs';
+import { useEffect } from 'react';
+
+// STOMP 구독 공통 hook
+export const useStompSubscription = (
+  destination: string,
+  callback: (message: any) => void,
+) => {
+  useEffect(() => {
+    const client = getStompClient();
+    let subscription: StompSubscription | null = null;
+
+    const subscribe = () => {
+      if (subscription) return;
+
+      subscription = client.subscribe(destination, (msg) => {
+        callback(JSON.parse(msg.body));
+      });
+    };
+
+    if (client.connected) {
+      subscribe();
+    } else {
+      addOnConnectListener(subscribe);
+    }
+
+    return () => {
+      if (subscription) {
+        subscription.unsubscribe();
+      }
+      removeOnConnectListener(subscribe);
+    };
+  }, [destination]);
+};

--- a/lib/socket/client.ts
+++ b/lib/socket/client.ts
@@ -5,19 +5,34 @@ import SockJS from 'sockjs-client';
 import { useAuthStore } from '../store/authStore';
 
 let client: Client | null = null;
+let currentToken: string | null = null;
 
-// websocket 연결을 위한 StompClient 객체 생성
+// 연결 성공 리스너 (subscribe 할 때 사용)
+const connectListeners: (() => void)[] = [];
+export const addOnConnectListener = (fn: () => void) => {
+  connectListeners.push(fn);
+};
+export const removeOnConnectListener = (fn: () => void) => {
+  const idx = connectListeners.indexOf(fn);
+  if (idx !== -1) connectListeners.splice(idx, 1);
+};
+
+// STOMP Client 생성 및 반환
 export const getStompClient = () => {
   const accessToken = useAuthStore.getState().accessToken;
-  if (!accessToken) {
-    throw new Error('accessToken 없음');
+  if (!accessToken) throw new Error('accessToken 없음');
+
+  const websocketUrl = process.env.NEXT_PUBLIC_WS_LOCAL_URL;
+  if (!websocketUrl) throw new Error('WebSocket URL 없음');
+
+  // 토큰 바뀌면 재생성 -> 연결 해제 후 재연결 ("WebSocket은 HTTP처럼 매 요청마다 인증하지 않는다" : 연결 시 1번 인증 -> 이후 계속 유지)
+  if (client && currentToken !== accessToken) {
+    client.deactivate();
+    client = null;
   }
   if (client) return client;
 
-  const websocketUrl = process.env.NEXT_PUBLIC_WS_LOCAL_URL;
-  if (!websocketUrl) {
-    throw new Error('WebSocket URL 없음');
-  }
+  currentToken = accessToken;
 
   client = new Client({
     webSocketFactory: () => new SockJS(websocketUrl),
@@ -25,6 +40,20 @@ export const getStompClient = () => {
       Authorization: `Bearer ${accessToken}`,
     },
     reconnectDelay: 5000,
+    onConnect: (frame) => {
+      console.log('✅ WebSocket 연결 성공 => ', frame.headers);
+      // 등록된 모든 리스너 실행
+      connectListeners.forEach((listener) => listener());
+    },
+    onStompError: (frame) => {
+      console.log('❌ STOMP 에러', frame.headers['message']);
+    },
+    onWebSocketError: (event) => {
+      console.log('❌ WebSocket 연결 실패', event);
+    },
+    onWebSocketClose: () => {
+      console.log('⚠️ WebSocket 연결 종료');
+    },
     debug: (str) => console.log(str),
   });
 


### PR DESCRIPTION


## #️⃣연관된 이슈

> #63 

  <br/>

## ✔️PR Checklist

- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

<br/>

## 작업 내용
- STOMP Client의 onConnect 덮어쓰기 문제 해결
  - 기존: 각 hook 및 컴포넌트에서 client.onConnect를 직접 할당 → 마지막 할당으로 덮어쓰기 발생
  - 개선: connectListeners 배열을 통한 이벤트 리스너 패턴 도입

- WebSocket 연결 성공 시 등록된 모든 리스너 실행하도록 구조 변경
  - client.ts에서 onConnect를 단일 진입점으로 관리

- hook(useChatUsers, useChatMessages)에서 subscribe 로직 분리
  - subscribe 함수를 별도로 정의하여 재사용 가능하도록 개선

- client.connected 상태에 따라 분기 처리
  - 이미 연결된 경우 즉시 subscribe
  - 미연결 상태에서는 onConnect 리스너 등록

- WebSocket reconnect 대응 구조 개선
  - onConnect 재실행 시 자동으로 subscribe 재등록 가능하도록 설계

- useEffect cleanup에서 subscription 및 onConnect listener 제거
  - 메모리 누수 및 중복 subscribe 방지

- 중복 subscribe 방지 로직 추가
  - subscription 존재 여부 체크

## 요약
- onConnect 덮어쓰기 문제 해결 (리스너 패턴 도입)
- subscribe 로직 분리 및 공통 패턴 적용
- reconnect 시 자동 재구독 구조 개선
- cleanup에서 subscription 및 listener 제거
