### PR TITLE
[FIX] (chat) new SockJS(websocketUrl) 주소 변경 및 STOMP client 비활성 상태 재사용 문제 및 lifecycle 충돌 해결

### DIFF
--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -1,25 +1,51 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Button from '../ui/Button';
 import InputText from '../ui/InputText';
 import MessageItem from './MessageItem';
 import { useChatMessages } from '@/hooks/chat/useChatMessages';
+import BottomButton from '../common/BottomButton';
 
 export default function ChatPanel() {
   const [chat, setChat] = useState('');
   const { messages, sendMessage } = useChatMessages();
 
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const isAtBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 50;
+    // el.scrollTop(현재 스크롤 위치), el.scrollHeight(전체 높이), el.clientHeight(보이는 영역 높이)
+
+    if (isAtBottom) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [messages]);
+
+  const handleSendMessage = () => {
+    if (!chat) return;
+    sendMessage(chat);
+    setChat('');
+  };
+
   return (
-    <div className="flex-1 rounded-md border border-primitive-grayPrimary p-4 flex flex-col">
-      <div className="pb-4 pt-4 overflow-y-auto flex-1 flex flex-col-reverse gap-2">
-        {messages.map((message) => (
-          <MessageItem
-            key={message.timestamp}
-            memberId={message.memberId}
-            nickname={message.nickname}
-            message={message.message}
-            timestamp={message.timestamp}
-          />
-        ))}
+    <div className="h-full relative flex-1 rounded-md border border-primitive-grayPrimary p-4 flex flex-col">
+      <div className="flex-1 h-full relative overflow-hidden">
+        <div ref={containerRef} className="h-full overflow-y-auto">
+          <div className="pb-4 pt-4 min-h-full flex flex-col gap-2 justify-end">
+            {messages.map((message) => (
+              <MessageItem
+                key={message.timestamp}
+                memberId={message.memberId}
+                nickname={message.nickname}
+                message={message.message}
+                timestamp={message.timestamp}
+              />
+            ))}
+          </div>
+        </div>
+        <BottomButton containerRef={containerRef} />
       </div>
       <div className="flex gap-2 pt-4 h-15 border-t border-primitive-grayPrimary">
         <InputText
@@ -27,13 +53,19 @@ export default function ChatPanel() {
           placeholder="채팅을 입력해주세요."
           className="flex-1 h-full"
           value={chat}
+          autoComplete="off"
           onChange={(e) => setChat(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              handleSendMessage();
+            }
+          }}
         />
         <Button
           variant="primary"
           size="sm"
           className="h-full"
-          onClick={() => sendMessage(chat)}
+          onClick={handleSendMessage}
           disabled={!chat}
         >
           전송

--- a/components/chat/ChatWrap.tsx
+++ b/components/chat/ChatWrap.tsx
@@ -19,6 +19,11 @@ export default function ChatWrap() {
       return;
     }
     const client = getStompClient(); // websocket 연결
+    if (!client) {
+      alert('WebSocket 연결 실패');
+      router.replace('/login');
+      return;
+    }
     return () => {
       client.deactivate(); // 페이지 나가거나, 토큰 변경 시 websocket 연결 해제 (disconnect)
     };

--- a/components/common/BottomButton.tsx
+++ b/components/common/BottomButton.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Button from '@/components/ui/Button';
+import { MdKeyboardArrowDown } from 'react-icons/md';
+
+type Props = {
+  containerRef: React.RefObject<HTMLDivElement | null>;
+};
+
+export default function BottomButton({ containerRef }: Props) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const handleScroll = () => {
+      const isAtBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 50;
+
+      setVisible(!isAtBottom);
+    };
+
+    el.addEventListener('scroll', handleScroll);
+    handleScroll();
+
+    return () => {
+      el.removeEventListener('scroll', handleScroll);
+    };
+  }, [containerRef]);
+
+  if (!visible) return null;
+
+  return (
+    <div className="absolute bottom-3 right-1/2 translate-x-1/2 z-50">
+      <Button
+        className="rounded-full border border-primitive-grayPrimary bg-primitive-white shadow-[0_0_5px_0_rgba(0,0,0,0.2)]"
+        variant="icon"
+        size="lg"
+        onClick={() => {
+          const el = containerRef.current;
+          if (!el) return;
+
+          el.scrollTo({
+            top: el.scrollHeight,
+            behavior: 'smooth',
+          });
+        }}
+      >
+        <MdKeyboardArrowDown className="w-[60%] h-[60%]" />
+      </Button>
+    </div>
+  );
+}

--- a/hooks/chat/useChatMessages.ts
+++ b/hooks/chat/useChatMessages.ts
@@ -15,7 +15,7 @@ export const useChatMessages = () => {
   // 채팅 메시지 전송 행동 함수
   const sendMessage = (chat: string) => {
     const client = getStompClient();
-
+    if (!client) return;
     client.publish({
       destination: '/pub/chat/message',
       body: JSON.stringify({ message: chat }),

--- a/hooks/chat/useStompSubscription.ts
+++ b/hooks/chat/useStompSubscription.ts
@@ -13,6 +13,7 @@ export const useStompSubscription = (
 ) => {
   useEffect(() => {
     const client = getStompClient();
+    if (!client) return;
     let subscription: StompSubscription | null = null;
 
     const subscribe = () => {

--- a/lib/socket/client.ts
+++ b/lib/socket/client.ts
@@ -20,20 +20,29 @@ export const removeOnConnectListener = (fn: () => void) => {
 // STOMP Client 생성 및 반환
 export const getStompClient = () => {
   const accessToken = useAuthStore.getState().accessToken;
-  if (!accessToken) throw new Error('accessToken 없음');
+  if (!accessToken) return null;
 
   const websocketUrl = process.env.NEXT_PUBLIC_WS_LOCAL_URL;
-  if (!websocketUrl) throw new Error('WebSocket URL 없음');
+  if (!websocketUrl) return null;
 
   // 토큰 바뀌면 재생성 -> 연결 해제 후 재연결 ("WebSocket은 HTTP처럼 매 요청마다 인증하지 않는다" : 연결 시 1번 인증 -> 이후 계속 유지)
   if (client && currentToken !== accessToken) {
+    console.log('🔥 CLIENT EXIST AND TOKEN CHANGED => client deactivate');
     client.deactivate();
     client = null;
   }
+
+  // 연결 종료 시 재생성
+  if (client && !client.active) {
+    console.log('🔥 DEAD CLIENT → recreate');
+    client = null;
+  }
+
   if (client) return client;
 
   currentToken = accessToken;
 
+  console.log('🔥 NEW CLIENT CREATED');
   client = new Client({
     webSocketFactory: () => new SockJS(websocketUrl),
     connectHeaders: {
@@ -54,7 +63,7 @@ export const getStompClient = () => {
     onWebSocketClose: () => {
       console.log('⚠️ WebSocket 연결 종료');
     },
-    debug: (str) => console.log(str),
+    // debug: (str) => console.log(str),
   });
 
   client.activate();

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,8 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   /* config options here */
+  reactStrictMode: false,
 };
 
 export default nextConfig;


### PR DESCRIPTION


## #️⃣연관된 이슈

> #63 

  <br/>

## ✔️PR Checklist

- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

<br/>

## STOMP client 수정 사항
- 웹소켓 통신용 STOMP의 client 를 만들때, client = new Client({ webSocketFactory: () => new SockJS(websocketUrl), 여기서 websocketUrl이 ws:// 가 아닌 http:// 로 들어가야함(sockJS 규칙, 내부적으로 ws로 업그레이드)
- WebSocket(STOMP) client가 deactivate 이후 재사용되던 문제 해결
  - client.active 상태를 체크하여 inactive client일 경우 재생성하도록 수정

- React Strict Mode 환경에서 useEffect cleanup에 의해 client가 즉시 deactivate 되는 문제 대응

- ChatWrap 컴포넌트에서 WebSocket 연결/해제 로직 정리
  - 페이지 진입 시 connect (getStompClient)
  - 페이지 이탈 시 disconnect (client.deactivate)

- STOMP client singleton 구조 유지하면서 lifecycle 기반 재생성 로직 보완

- 안정적인 재접속을 위해 다음 조건 추가:
  - 토큰 변경 시 client 재생성
  - client가 inactive 상태일 경우 재생성

## UI 수정 사항
- 최신 채팅이 채팅창 맨 아래에 쌓이게 함
- BottomButton 추가하여 채팅창 스크롤 위로 올렸을 시 노출