### PR TITLE
[FIX] Mac 한글 입력 시 채팅 중복 전송 및 key 충돌 문제 해결

### DIFF
--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -9,6 +9,9 @@ export default function ChatPanel() {
   const [chat, setChat] = useState('');
   const { messages, sendMessage } = useChatMessages();
 
+  // (mac환경) 한글 입력(IME) 조합 중인지 여부 (Enter 중복 전송 방지)
+  const [isComposing, setIsComposing] = useState(false);
+
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -34,9 +37,9 @@ export default function ChatPanel() {
       <div className="flex-1 h-full relative overflow-hidden">
         <div ref={containerRef} className="h-full overflow-y-auto">
           <div className="pb-4 pt-4 min-h-full flex flex-col gap-2 justify-end">
-            {messages.map((message) => (
+            {messages.map((message, index) => (
               <MessageItem
-                key={message.timestamp}
+                key={`${message.timestamp}-${index}`}
                 memberId={message.memberId}
                 nickname={message.nickname}
                 message={message.message}
@@ -55,7 +58,10 @@ export default function ChatPanel() {
           value={chat}
           autoComplete="off"
           onChange={(e) => setChat(e.target.value)}
+          onCompositionStart={() => setIsComposing(true)}
+          onCompositionEnd={() => setIsComposing(false)}
           onKeyDown={(e) => {
+            if (isComposing) return;
             if (e.key === 'Enter') {
               handleSendMessage();
             }


### PR DESCRIPTION


## #️⃣연관된 이슈

> #63 

  <br/>

## ✔️PR Checklist

- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

<br/>

## 🔎 작업 내용
- 한글 IME 입력 중 Enter 이벤트로 인한 메시지 중복 전송 문제 수정
- onKeyDown에서 isComposing 체크 로직 추가
- compositionStart / compositionEnd 이벤트로 입력 상태 제어
- 메시지 리스트 key를 timestamp 단일 값에서 index 조합으로 변경하여 key 충돌 방지
