### PR TITLE
[FIX] 글 수정 페이지 상세 데이터 캐싱 불일치 문제 해결 및 API 요청 구조 개선

### DIFF
--- a/actions/post/post.actions.ts
+++ b/actions/post/post.actions.ts
@@ -1,7 +1,18 @@
 'use server';
 
-import { updatePost } from '@/lib/api/server/post/post';
+import { createPost, updatePost } from '@/lib/api/server/post/post';
 import { revalidateTag } from 'next/cache';
+
+// 글 작성
+export async function createPostAction(formData: FormData, category: string) {
+  try {
+    const data = await createPost(formData, category);
+    return data;
+  } catch (error) {
+    console.error('게시글 작성 실패: ', error);
+    throw error;
+  }
+}
 
 // 글 수정
 export async function updatePostAction(postId: number, formData: FormData) {

--- a/app/(main)/posts/[postId]/edit/ClientPage.tsx
+++ b/app/(main)/posts/[postId]/edit/ClientPage.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import PostWriteForm from '@/components/posts/write/PostWriteForm';
+import {
+  addDataAttMediaIdToImages,
+  replacePlaceholdersWithUrls,
+} from '@/components/posts/write/utils/imageProcessor';
+import { PostData } from '@/types/api/postDetail';
+
+// 글 수정 client page
+export default function ClientPage({
+  post,
+  postId,
+}: {
+  post: PostData;
+  postId: number;
+}) {
+  // placeholder를 실제 이미지 URL로 변환
+  const contentWithImages = replacePlaceholdersWithUrls(
+    post.content,
+    post.mediaList,
+  );
+
+  // 이미지에 data-media-id 속성 추가
+  const contentWithDataAttMediaId = addDataAttMediaIdToImages(
+    contentWithImages,
+    post.mediaList,
+  );
+
+  return (
+    <PostWriteForm
+      mode="edit"
+      postId={Number(postId)}
+      initialData={{
+        title: post.title,
+        content: contentWithDataAttMediaId,
+        category: post.category,
+      }}
+    />
+  );
+}

--- a/app/(main)/posts/[postId]/edit/error.tsx
+++ b/app/(main)/posts/[postId]/edit/error.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  return (
+    <div className="py-20 text-center">
+      <p>게시글 수정 중 오류가 발생했습니다.</p>
+      <button onClick={() => reset()} className="mt-4">
+        다시 시도
+      </button>
+    </div>
+  );
+}

--- a/app/(main)/posts/[postId]/edit/page.tsx
+++ b/app/(main)/posts/[postId]/edit/page.tsx
@@ -1,49 +1,23 @@
-'use client';
-
-import { useParams } from 'next/navigation';
-import { usePostDetailQuery } from '@/query/post/usePostDetailQuery';
-import PostWriteForm from '@/components/posts/write/PostWriteForm';
-import {
-  addDataAttMediaIdToImages,
-  replacePlaceholdersWithUrls,
-} from '@/components/posts/write/utils/imageProcessor';
+import { notFound } from 'next/navigation';
+import { fetchPostDetail } from '@/lib/api/server/post/post';
+import ClientPage from './ClientPage';
 
 // 글 수정
-export default function PostEditPage() {
-  const params = useParams();
-  const postId = params.postId;
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ postId: string }>;
+}) {
+  const { postId } = await params;
 
-  // 기존 상세 조회 API 재사용
-  const { data: postDetailResponse, isLoading } = usePostDetailQuery(
-    Number(postId),
-  );
+  // 글 상세 조회 API -> 글 수정 form 초기값 설정
+  const postDetailResponse = await fetchPostDetail(Number(postId));
 
-  if (isLoading) return <div>Loading...</div>;
+  if (postDetailResponse.code !== 200) {
+    notFound();
+  }
+  const postData = postDetailResponse.data;
+  if (!postData) notFound();
 
-  const post = postDetailResponse?.data;
-  if (!post) return <div>글을 찾을 수 없습니다.</div>;
-
-  // placeholder를 실제 이미지 URL로 변환
-  const contentWithImages = replacePlaceholdersWithUrls(
-    post.content,
-    post.mediaList,
-  );
-
-  // 이미지에 data-media-id 속성 추가
-  const contentWithDataAttMediaId = addDataAttMediaIdToImages(
-    contentWithImages,
-    post.mediaList,
-  );
-
-  return (
-    <PostWriteForm
-      mode="edit"
-      postId={Number(postId)}
-      initialData={{
-        title: post.title,
-        content: contentWithDataAttMediaId,
-        category: post.category,
-      }}
-    />
-  );
+  return <ClientPage post={postData} postId={Number(postId)} />;
 }

--- a/components/posts/write/PostWriteForm.tsx
+++ b/components/posts/write/PostWriteForm.tsx
@@ -6,20 +6,12 @@ import { Heading } from '@/components/ui/Heading';
 import InputText from '@/components/ui/InputText';
 import Button from '@/components/ui/Button';
 import { useState, useEffect, useRef } from 'react';
-import {
-  useCreatePostMutation,
-  useUpdatePostMutation,
-} from '@/query/post/usePostMutations';
-import {
-  replaceImagesWithPlaceholders,
-  getMediaCountInContent,
-} from './utils/imageProcessor';
+import { getMediaCountInContent } from './utils/imageProcessor';
 import { usePostMediaManager } from './hooks/usePostMediaManager';
-import { useRouter } from 'next/navigation';
 import SelectCategory from './SelectCategory';
 import type { CategoryData } from '@/types/api/category';
-import { buildEditMediaPayload } from './utils/mediaDiff';
-import { updatePostAction } from '@/actions/post/update.actions';
+import { usePostSubmit } from './hooks/usePostSubmit';
+import { buildPostFormData, buildPostPayload } from './utils/postSubmission';
 
 type PostWriteFormProps = {
   mode: 'create' | 'edit';
@@ -36,7 +28,6 @@ export default function PostWriteForm({
   initialData,
   postId,
 }: PostWriteFormProps) {
-  const router = useRouter();
   const [title, setTitle] = useState(initialData?.title || '');
   const [category, setCategory] = useState(
     initialData?.category?.categoryAddress || '',
@@ -49,8 +40,12 @@ export default function PostWriteForm({
   const { handleMediaUpload, getMediaFiles, clearMedia } = usePostMediaManager({
     getEditorHtml,
   });
-  const createPostMutate = useCreatePostMutation();
-  const updatePostMutate = useUpdatePostMutation();
+  const { submitPost, isPending, isSuccess } = usePostSubmit({ clearMedia });
+  const [canSubmit, setCanSubmit] = useState(title && category);
+
+  useEffect(() => {
+    setCanSubmit(title && category);
+  }, [title, category]);
 
   // (수정 모드) 에디터에 초기 콘텐츠 설정
   useEffect(() => {
@@ -58,71 +53,6 @@ export default function PostWriteForm({
       editor.commands.setContent(initialData.content);
     }
   }, [mode, editor, initialData?.content]);
-
-  // 글 작성 or 수정 api 호출
-  async function submitPostMutation({
-    mode,
-    postId,
-    formData,
-    category,
-  }: {
-    mode: 'create' | 'edit';
-    postId?: number;
-    formData: FormData;
-    category: string;
-  }) {
-    if (mode === 'create') {
-      return createPostMutate.mutate(
-        { formData, category },
-        {
-          onSuccess: (data) => {
-            clearMedia();
-            alert('글 작성 완료!');
-            if (data.code === 201 && data.data?.postId) {
-              router.push(`/posts/${data.data.postId}`);
-            }
-          },
-          onError: (error) => {
-            console.error('글 작성 실패:', error);
-          },
-        },
-      );
-    }
-
-    if (mode === 'edit') {
-      if (!postId) {
-        alert('글 ID가 없습니다.');
-        return;
-      }
-
-      // server side action
-      try {
-        await updatePostAction(postId, formData);
-        clearMedia();
-        alert('글 수정 완료!');
-        router.push(`/posts/${postId}`);
-      } catch (error) {
-        console.error('글 수정 실패:', error);
-        alert('글 수정에 실패했습니다.');
-      }
-
-      // client side mutation
-      // return updatePostMutate.mutate(
-      //   { postId, formData },
-      //   {
-      //     onSuccess: (data) => {
-      //       clearMedia();
-      //       alert('글 수정 완료!');
-      //       router.push(`/posts/${postId}`);
-      //     },
-      //     onError: (error) => {
-      //       console.error('글 수정 실패:', error);
-      //       alert('글 수정에 실패했습니다.');
-      //     },
-      //   },
-      // );
-    }
-  }
 
   // 글 작성 완료 시 수행
   const handleSubmit = async () => {
@@ -134,54 +64,21 @@ export default function PostWriteForm({
 
     try {
       const html = editor.getHTML();
-      const processedHtml = replaceImagesWithPlaceholders(html);
       const newImageFiles = getMediaFiles(html);
-
-      // 1. 기본 payload
-      let postPayload = {
+      const postPayload = buildPostPayload({
+        mode,
         title,
-        content: processedHtml,
-      };
+        initialContent: initialData?.content,
+        currentHtml: html,
+      });
+      const formData = buildPostFormData(postPayload, newImageFiles);
 
-      // 2. edit이면 mediaDiff (html 내 미디어 파일 변경 정보) 추가
-      if (mode === 'edit') {
-        if (!postId) {
-          alert('글 ID가 없습니다.');
-          return;
-        }
-
-        const mediaPayload = buildEditMediaPayload(
-          initialData?.content || '',
-          html,
-        );
-
-        postPayload = {
-          ...postPayload,
-          ...mediaPayload,
-        };
-      }
-
-      // 3. formData는 공통
-      const formData = new FormData();
-      formData.append(
-        'post',
-        new Blob([JSON.stringify(postPayload)], {
-          type: 'application/json',
-        }),
-      );
-
-      newImageFiles.forEach((file) => formData.append('files', file));
-
-      // 4. submit 실행
-      await submitPostMutation({ mode, postId, formData, category });
+      await submitPost({ mode, postId, formData, category });
     } catch (error) {
       console.error('글 처리 실패:', error);
       alert('글 처리에 실패했습니다.');
     }
   };
-
-  const isPending =
-    mode === 'create' ? createPostMutate.isPending : updatePostMutate.isPending;
 
   return (
     <div>
@@ -233,11 +130,13 @@ export default function PostWriteForm({
           <Button
             variant="primary"
             onClick={handleSubmit}
-            disabled={isPending || !title || !category}
+            disabled={!canSubmit || isPending || isSuccess}
           >
-            {isPending
-              ? `${mode === 'create' ? '작성' : '수정'} 중...`
-              : `${mode === 'create' ? '작성' : '수정'} 완료`}
+            {isPending && isSuccess
+              ? '제출 완료'
+              : isPending
+                ? '제출 중...'
+                : '제출하기'}
           </Button>
         </div>
       </div>

--- a/components/posts/write/hooks/usePostSubmit.ts
+++ b/components/posts/write/hooks/usePostSubmit.ts
@@ -1,0 +1,69 @@
+import { useCallback, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  createPostAction,
+  updatePostAction,
+} from '@/actions/post/post.actions';
+
+type SubmitPostParams = {
+  mode: 'create' | 'edit';
+  postId?: number;
+  formData: FormData;
+  category: string;
+};
+
+type UsePostSubmitOptions = {
+  clearMedia: () => void;
+};
+
+export function usePostSubmit({ clearMedia }: UsePostSubmitOptions) {
+  const router = useRouter();
+  const [isPending, setIsPending] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
+
+  const submitPost = useCallback(
+    async ({ mode, postId, formData, category }: SubmitPostParams) => {
+      if (mode === 'create') {
+        try {
+          setIsPending(true);
+          const response = await createPostAction(formData, category);
+          clearMedia();
+          alert('글 작성 완료!');
+          setIsSuccess(true);
+          if (response.code === 201 && response.data?.postId) {
+            router.push(`/posts/${response.data.postId}`);
+          }
+        } catch (error) {
+          setIsPending(false);
+          setIsSuccess(false);
+          throw error;
+        }
+        return;
+      }
+
+      if (!postId) {
+        alert('글 ID가 없습니다.');
+        return;
+      }
+
+      try {
+        setIsPending(true);
+        await updatePostAction(postId, formData);
+        clearMedia();
+        alert('글 수정 완료!');
+        router.push(`/posts/${postId}`);
+      } catch (error) {
+        setIsPending(false);
+        setIsSuccess(false);
+        throw error;
+      }
+    },
+    [clearMedia, router],
+  );
+
+  return {
+    submitPost,
+    isPending: isPending,
+    isSuccess: isSuccess,
+  };
+}

--- a/components/posts/write/utils/postSubmission.ts
+++ b/components/posts/write/utils/postSubmission.ts
@@ -1,0 +1,49 @@
+import { replaceImagesWithPlaceholders } from './imageProcessor';
+import { buildEditMediaPayload } from './mediaDiff';
+
+type PostMode = 'create' | 'edit';
+
+type BuildPostPayloadParams = {
+  mode: PostMode;
+  title: string;
+  initialContent?: string;
+  currentHtml: string;
+};
+
+export function buildPostPayload({
+  mode,
+  title,
+  initialContent = '',
+  currentHtml,
+}: BuildPostPayloadParams) {
+  const processedHtml = replaceImagesWithPlaceholders(currentHtml);
+
+  const basePayload = {
+    title,
+    content: processedHtml,
+  };
+
+  if (mode === 'create') {
+    return basePayload;
+  }
+
+  const mediaPayload = buildEditMediaPayload(initialContent, currentHtml);
+  return {
+    ...basePayload,
+    ...mediaPayload,
+  };
+}
+
+export function buildPostFormData(postPayload: object, files: File[]) {
+  const formData = new FormData();
+
+  formData.append(
+    'post',
+    new Blob([JSON.stringify(postPayload)], {
+      type: 'application/json',
+    }),
+  );
+
+  files.forEach((file) => formData.append('files', file));
+  return formData;
+}

--- a/lib/api/server/apiHelpers.ts
+++ b/lib/api/server/apiHelpers.ts
@@ -6,7 +6,6 @@ interface ServerApiRequestOptionalParamsType {
   body?: any;
   options?: RequestInit;
   errorMessage?: string;
-  handle404?: boolean;
 }
 
 export function getServerApiBaseUrl(): string {
@@ -20,9 +19,8 @@ export function getServerApiBaseUrl(): string {
 async function handleServerResponse<T>(
   response: Response,
   errorMessage?: string,
-  handle404 = true,
 ): Promise<T> {
-  if (response.status === 404 && handle404) {
+  if (response.status === 404) {
     notFound();
   }
 
@@ -41,11 +39,7 @@ async function handleServerResponse<T>(
 
 export async function serverApiGet<T = any>(
   endpoint: string,
-  {
-    options,
-    errorMessage,
-    handle404 = true,
-  }: ServerApiRequestOptionalParamsType = {},
+  { options, errorMessage }: ServerApiRequestOptionalParamsType = {},
 ): Promise<T> {
   const baseUrl = getServerApiBaseUrl();
   const response = await apiRequest(`${baseUrl}${endpoint}`, {
@@ -57,17 +51,12 @@ export async function serverApiGet<T = any>(
     },
   });
 
-  return handleServerResponse<T>(response, errorMessage, handle404);
+  return handleServerResponse<T>(response, errorMessage);
 }
 
 export async function serverApiPost<T = any>(
   endpoint: string,
-  {
-    body,
-    options,
-    errorMessage,
-    handle404 = true,
-  }: ServerApiRequestOptionalParamsType = {},
+  { body, options, errorMessage }: ServerApiRequestOptionalParamsType = {},
 ): Promise<T> {
   const baseUrl = getServerApiBaseUrl();
   const response = await apiRequest(`${baseUrl}${endpoint}`, {
@@ -80,17 +69,12 @@ export async function serverApiPost<T = any>(
     body: body ? JSON.stringify(body) : undefined,
   });
 
-  return handleServerResponse<T>(response, errorMessage, handle404);
+  return handleServerResponse<T>(response, errorMessage);
 }
 
 export async function serverApiPut<T = any>(
   endpoint: string,
-  {
-    body,
-    options,
-    errorMessage,
-    handle404 = true,
-  }: ServerApiRequestOptionalParamsType = {},
+  { body, options, errorMessage }: ServerApiRequestOptionalParamsType = {},
 ): Promise<T> {
   const baseUrl = getServerApiBaseUrl();
   const response = await apiRequest(`${baseUrl}${endpoint}`, {
@@ -103,17 +87,12 @@ export async function serverApiPut<T = any>(
     body: body ? JSON.stringify(body) : undefined,
   });
 
-  return handleServerResponse<T>(response, errorMessage, handle404);
+  return handleServerResponse<T>(response, errorMessage);
 }
 
 export async function serverApiPatch<T = any>(
   endpoint: string,
-  {
-    body,
-    options,
-    errorMessage,
-    handle404 = true,
-  }: ServerApiRequestOptionalParamsType = {},
+  { body, options, errorMessage }: ServerApiRequestOptionalParamsType = {},
 ): Promise<T> {
   const baseUrl = getServerApiBaseUrl();
   const response = await apiRequest(`${baseUrl}${endpoint}`, {
@@ -126,17 +105,12 @@ export async function serverApiPatch<T = any>(
     body: body ? JSON.stringify(body) : undefined,
   });
 
-  return handleServerResponse<T>(response, errorMessage, handle404);
+  return handleServerResponse<T>(response, errorMessage);
 }
 
 export async function serverApiDelete<T = any>(
   endpoint: string,
-  {
-    body,
-    options,
-    errorMessage,
-    handle404 = true,
-  }: ServerApiRequestOptionalParamsType = {},
+  { body, options, errorMessage }: ServerApiRequestOptionalParamsType = {},
 ): Promise<T> {
   const baseUrl = getServerApiBaseUrl();
   const response = await apiRequest(`${baseUrl}${endpoint}`, {
@@ -149,17 +123,13 @@ export async function serverApiDelete<T = any>(
     body: body ? JSON.stringify(body) : undefined,
   });
 
-  return handleServerResponse<T>(response, errorMessage, handle404);
+  return handleServerResponse<T>(response, errorMessage);
 }
 
 export async function serverApiPostFormData<T = any>(
   endpoint: string,
   formData: FormData,
-  {
-    options,
-    errorMessage,
-    handle404 = true,
-  }: ServerApiRequestOptionalParamsType = {},
+  { options, errorMessage }: ServerApiRequestOptionalParamsType = {},
 ): Promise<T> {
   const baseUrl = getServerApiBaseUrl();
   const response = await apiRequest(`${baseUrl}${endpoint}`, {
@@ -168,17 +138,13 @@ export async function serverApiPostFormData<T = any>(
     body: formData,
   });
 
-  return handleServerResponse<T>(response, errorMessage, handle404);
+  return handleServerResponse<T>(response, errorMessage);
 }
 
 export async function serverApiPutFormData<T = any>(
   endpoint: string,
   formData: FormData,
-  {
-    options,
-    errorMessage,
-    handle404 = true,
-  }: ServerApiRequestOptionalParamsType = {},
+  { options, errorMessage }: ServerApiRequestOptionalParamsType = {},
 ): Promise<T> {
   const baseUrl = getServerApiBaseUrl();
   const response = await apiRequest(`${baseUrl}${endpoint}`, {
@@ -187,5 +153,5 @@ export async function serverApiPutFormData<T = any>(
     body: formData,
   });
 
-  return handleServerResponse<T>(response, errorMessage, handle404);
+  return handleServerResponse<T>(response, errorMessage);
 }

--- a/lib/api/server/apiRequest.ts
+++ b/lib/api/server/apiRequest.ts
@@ -1,31 +1,47 @@
 import { cookies } from 'next/headers';
 import { reissueAccessToken } from './auth/auth';
 
+type ApiRequestOptions = RequestInit & {
+  withAuth?: boolean;
+};
+
 export async function apiRequest(
   url: string,
-  options: RequestInit = {},
+  options: ApiRequestOptions = {},
 ): Promise<Response> {
-  const buildHeaders = async (): Promise<HeadersInit> => {
-    const cookieStore = await cookies();
-    return {
-      ...options.headers,
-      Cookie: cookieStore.toString(),
-    };
+  const { withAuth = true, ...rest } = options;
+
+  let headers: HeadersInit = {
+    ...rest.headers,
   };
 
-  const headers = await buildHeaders();
+  // ✅ 인증 필요할 때만 cookies 사용
+  // Next.js에서 서버 fetch 내에 cookies 사용 시 => Next.js가 "이 요청은 사용자마다 결과가 달라질 수 있음" 라고 판단 => 캐시 비활성화
+  // 👉 인증 필수 api 요청 시 => 캐시 포기
+  if (withAuth) {
+    const cookieStore = await cookies();
+    headers = {
+      ...headers,
+      Cookie: cookieStore.toString(),
+    };
+  }
 
   let response = await fetch(url, {
-    ...options,
+    ...rest,
     headers,
   });
 
-  if (response.status === 401) {
+  if (response.status === 401 && withAuth) {
     await reissueAccessToken();
-    const retryHeaders = await buildHeaders();
+
+    const cookieStore = await cookies();
+    const retryHeaders = {
+      ...headers,
+      Cookie: cookieStore.toString(),
+    };
 
     response = await fetch(url, {
-      ...options,
+      ...rest,
       headers: retryHeaders,
     });
   }

--- a/lib/api/server/post/post.ts
+++ b/lib/api/server/post/post.ts
@@ -1,5 +1,9 @@
 import { PostDetailResponse } from '@/types/api/postDetail';
-import { serverApiGet, serverApiPutFormData } from '../apiHelpers';
+import {
+  serverApiGet,
+  serverApiPostFormData,
+  serverApiPutFormData,
+} from '../apiHelpers';
 
 // 게시글 상세 조회
 export async function fetchPostDetail(
@@ -9,9 +13,18 @@ export async function fetchPostDetail(
     options: {
       next: { revalidate: 60, tags: [`post-${postId}`] }, // fetch 결과를 60초 동안 캐싱
     },
-    errorMessage: '게시글 조회 실패',
-    handle404: true,
   });
+}
+
+// 게시글 작성
+export async function createPost(
+  formData: FormData,
+  category: string,
+): Promise<PostDetailResponse> {
+  return serverApiPostFormData<PostDetailResponse>(
+    `/posts/${category}`,
+    formData,
+  );
 }
 
 // 게시글 수정
@@ -19,12 +32,5 @@ export async function updatePost(
   postId: number,
   formData: FormData,
 ): Promise<PostDetailResponse> {
-  return serverApiPutFormData<PostDetailResponse>(
-    `/posts/${postId}`,
-    formData,
-    {
-      errorMessage: '게시글 수정 실패',
-      handle404: true,
-    },
-  );
+  return serverApiPutFormData<PostDetailResponse>(`/posts/${postId}`, formData);
 }

--- a/types/api/postDetail.ts
+++ b/types/api/postDetail.ts
@@ -26,3 +26,6 @@ export interface MediaItem {
 
 // 게시글 상세 조회 API 응답 타입
 export type PostDetailResponse = ApiResponse<PostDetailData>;
+
+// 게시글 상세 데이터 타입
+export type PostData = NonNullable<PostDetailResponse['data']>;


### PR DESCRIPTION


## #️⃣연관된 이슈

> #86 

  <br/>

## ✔️PR Checklist

- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

<br/>

## 작업 내용
- 글 수정 페이지에서 React Query 기반 상세 조회 제거
- server fetch 기반으로 데이터 패칭 통일
- revalidateTag와 fetch tags 기반 캐싱 전략 일관화

- apiRequest 리팩토링
  - withAuth 옵션 추가 (cookies 사용 분기)
  - Content-Type 설정 제거 (API helper로 책임 이동)
  - FormData 요청 시 500 에러 발생 문제 해결

- 글 작성(create) api 방식 변경
  - 기존 : ReactQuery
  - 변경 : 글 수정과 동일한 서버 fetch 방식
  - 최종 : 글 상세 조회, 글 작성, 글 수정 => Next.js fetch로 api 호출

- 서버 캐싱 / 클라이언트 캐싱 혼용으로 발생하던 데이터 불일치 문제 해결

### 추가 작업
- PostWriteForm 제출 로직 분리로 컴포넌트 단순화
   - payload/formData 생성은 utils로 이동
   - API 호출/라우팅/pending 관리는 hook으로 이동