### PR TITLE
[REFACTOR] 게시글 상세 조회 api -> option 명시적으로 기입

### DIFF
--- a/lib/api/server/post/post.ts
+++ b/lib/api/server/post/post.ts
@@ -18,7 +18,6 @@ export async function fetchPostList(
   const sp = buildSearchParams(params);
   return serverApiGet<PostListResponse>(`/posts?${sp.toString()}`, {
     options: {
-      // next: { revalidate: 60, tags: ['post-list'] },
       cache: 'no-store',
       withAuth: false,
     },
@@ -29,7 +28,12 @@ export async function fetchPostList(
 export async function fetchPostDetail(
   postId: number,
 ): Promise<PostDetailResponse> {
-  return serverApiGet<PostDetailResponse>(`/posts/${postId}`);
+  return serverApiGet<PostDetailResponse>(`/posts/${postId}`, {
+    options: {
+      cache: 'no-store',
+      withAuth: true,
+    },
+  });
 }
 
 // 게시글 작성


### PR DESCRIPTION

## #️⃣연관된 이슈

> #93 

  <br/>

## ✔️PR Checklist

- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

<br/>

## 🔎 작업 내용
- 서버용 fetch 함수에서 options내에서 withAuth를 true로 넣으면, cookise()를 사용하기 때문에, 동적인 fetch라 여겨서 자동으로 cache: 'no-store'처럼 캐싱이 안됨.
- 그러나 이렇게 명시적으로 적어주는게 "의도를 명확히 + 미래 버그 방지" 목적으로 좋다하여 수정함.

