### PR TITLE
[REFACTOR] AccessToken (쿠키) 이용해서 Next.js 앱 에서 라우팅 단계에서 접근 불가 처리

### DIFF
--- a/app/admin/AdminLayoutClient.tsx
+++ b/app/admin/AdminLayoutClient.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import Main from './Main';
+import Sidebar from './Sidebar';
+import { BiCategory } from 'react-icons/bi';
+import { FiUser } from 'react-icons/fi';
+import { usePathname } from 'next/navigation';
+import type { NavMenu } from './types';
+
+const navMenus: NavMenu[] = [
+  {
+    name: '카테고리 관리',
+    href: '/admin/category',
+    icon: <BiCategory />,
+  },
+  {
+    name: '회원 관리',
+    href: '/admin/member',
+    icon: <FiUser />,
+  },
+];
+
+export default function AdminLayoutClient({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const pathname = usePathname();
+
+  return (
+    <div className="fixed left-0 right-0 top-0 bottom-0 flex">
+      <Sidebar navMenus={navMenus} currentPath={pathname} />
+      <Main navMenus={navMenus} currentPath={pathname}>
+        {children}
+      </Main>
+    </div>
+  );
+}

--- a/app/admin/Main.tsx
+++ b/app/admin/Main.tsx
@@ -1,5 +1,5 @@
 import { Heading } from '@/components/ui/Heading';
-import { NavMenu } from './layout';
+import type { NavMenu } from './types';
 
 interface MainProps {
   children: React.ReactNode;

--- a/app/admin/Sidebar.tsx
+++ b/app/admin/Sidebar.tsx
@@ -1,7 +1,7 @@
 import Logo from '@/components/common/Logo';
 import Button from '@/components/ui/Button';
 import { RiMenuFold2Line, RiMenuFoldLine } from 'react-icons/ri';
-import { NavMenu } from '@/app/admin/layout';
+import type { NavMenu } from '@/app/admin/types';
 import Link from 'next/link';
 import { twMerge } from 'tailwind-merge';
 import { useState } from 'react';

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,65 +1,30 @@
-'use client';
+import type { ReactNode } from 'react';
+import { redirect } from 'next/navigation';
+import { serverApiGet } from '@/lib/api/server/apiHelpers';
+import { ApiError } from '@/lib/error/api';
+import type { MemberInfoResponse } from '@/types/api/member';
+import AdminLayoutClient from './AdminLayoutClient';
 
-import { useEffect } from 'react';
-import Main from './Main';
-import Sidebar from './Sidebar';
-import { BiCategory } from 'react-icons/bi';
-import { FiUser } from 'react-icons/fi';
-import { usePathname, useRouter } from 'next/navigation';
-import { useAuthStore } from '@/lib/store/authStore';
+export type { NavMenu } from './types';
 
-export interface NavMenu {
-  name: string;
-  href: string;
-  icon: React.ReactNode;
-}
-
-export default function AdminLayout({
+export default async function AdminLayout({
   children,
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
-  const pathname = usePathname();
-  const router = useRouter();
-
-  const isInitialized = useAuthStore((state) => state.isInitialized);
-  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
-  const role = useAuthStore((state) => state.role);
-
-  useEffect(() => {
-    if (!isInitialized) return;
-    if (!isLoggedIn) {
-      alert('로그인이 필요합니다.');
-      router.push('/login');
-      return;
-    } else if (role !== 'ROLE_ADMIN') {
-      alert('관리자 권한이 필요합니다.');
-      router.push('/');
-      return;
+  try {
+    const res = await serverApiGet<MemberInfoResponse>('/members/me', {
+      errorMessage: '내 정보 조회 실패',
+    });
+    if (res.data?.role !== 'ROLE_ADMIN') {
+      redirect('/');
     }
-  }, [isInitialized, isLoggedIn, role, router]);
+  } catch (e) {
+    if (e instanceof ApiError && e.code === 401) {
+      redirect('/login');
+    }
+    throw e;
+  }
 
-  const navMenus: NavMenu[] = [
-    {
-      name: '카테고리 관리',
-      href: '/admin/category',
-      icon: <BiCategory />,
-    },
-    {
-      name: '회원 관리',
-      href: '/admin/member',
-      icon: <FiUser />,
-    },
-  ];
-
-  return (
-    <div className="fixed left-0 right-0 top-0 bottom-0 flex">
-      {/* 사이드바 */}
-      <Sidebar navMenus={navMenus} currentPath={pathname} />
-      {/* 메인 */}
-      <Main navMenus={navMenus} currentPath={pathname}>
-        {children}
-      </Main>
-    </div>
-  );
+  return <AdminLayoutClient>{children}</AdminLayoutClient>;
 }

--- a/app/admin/types.ts
+++ b/app/admin/types.ts
@@ -1,0 +1,7 @@
+import type { ReactNode } from 'react';
+
+export interface NavMenu {
+  name: string;
+  href: string;
+  icon: ReactNode;
+}

--- a/lib/constants/auth-cookies.ts
+++ b/lib/constants/auth-cookies.ts
@@ -1,0 +1,2 @@
+/** 백엔드가 발급하는 HTTP-only 액세스 토큰 쿠키 이름 */
+export const ACCESS_TOKEN_COOKIE_NAME = 'AccessToken';

--- a/lib/utils/auth-token.ts
+++ b/lib/utils/auth-token.ts
@@ -1,5 +1,4 @@
 import { UserRole } from '@/types/api/auth';
-import { useAuthStore } from '../store/authStore';
 
 // JWT 토큰 관련 유틸리티 함수
 interface JWTPayload {

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { ACCESS_TOKEN_COOKIE_NAME } from '@/lib/constants/auth-cookies';
+import {
+  decodeJWT,
+  getUserRoleFromToken,
+  isTokenExpired,
+} from '@/lib/utils/auth-token';
+
+export const config = {
+  matcher: ['/admin', '/admin/:path*', '/mypage', '/mypage/:path*'],
+};
+
+export function proxy(request: NextRequest) {
+  const pathname = request.nextUrl.pathname;
+  const isAdminRoute = pathname.startsWith('/admin');
+
+  const accessToken = request.cookies.get(ACCESS_TOKEN_COOKIE_NAME)?.value;
+
+  if (!accessToken) {
+    return NextResponse.redirect(new URL('/login', request.url));
+  }
+
+  const payload = decodeJWT(accessToken);
+  if (!payload) {
+    return NextResponse.redirect(new URL('/login', request.url));
+  }
+
+  if (isTokenExpired(accessToken)) {
+    return NextResponse.next();
+  }
+
+  if (isAdminRoute) {
+    const role = getUserRoleFromToken(accessToken);
+    if (role !== null && role !== 'ROLE_ADMIN') {
+      return NextResponse.redirect(new URL('/', request.url));
+    }
+  }
+
+  return NextResponse.next();
+}


### PR DESCRIPTION


## #️⃣연관된 이슈

> #97 

  <br/>

## ✔️PR Checklist

- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

<br/>

## 작업 내용
AccessToken(HttpOnly 쿠키)을 기준으로 인증이 필요한 경로를 라우팅 단계와 서버 렌더 단계에서 처리한다.

- Proxy(proxy.ts): /admin·/mypage에 대해 쿠키 존재·JWT 형식·만료 여부를 검사하고, /admin은 JWT role이 있으면 ROLE_ADMIN이 아닐 때 홈으로 리다이렉트한다. 만료 토큰은 서버에서 재발급·/members/me 검증이 가능하도록 통과시킨다.
- app/admin/layout.tsx: 서버 컴포넌트에서 /members/me로 역할을 최종 확인하고, 비관리자·비로그인(401) 시 각각 홈·로그인으로 redirect. 기존 Zustand·useEffect 기반 클라이언트 가드 제거.
- AdminLayoutClient로 관리자 UI(사이드바·메인)만 클라이언트로 분리. NavMenu 타입은 app/admin/types.ts로 이동.
- Next.js 16에 맞춰 middleware.ts를 proxy.ts로 이전(export proxy).
- auth-token.ts에서 미사용 import 정리. ACCESS_TOKEN_COOKIE_NAME 상수 추가.

BREAKING CHANGE: 없음 (동작은 쿠키·백엔드 계약이 기존과 동일할 때 기대)
