### PR TITLE
[REFACTOR] 게시글 생성/수정/삭제 (Next.js fetch 캐시) 후 마이페이지 캐시(ReactQuery) 동기화 …

### DIFF
--- a/components/posts/detail/ownerActions/Delete.tsx
+++ b/components/posts/detail/ownerActions/Delete.tsx
@@ -4,18 +4,34 @@ import { useState } from 'react';
 import DeleteModal from '@/components/common/modal/DeleteModal';
 import { deletePostAction } from '@/actions/post/post.actions';
 import { getErrorMessage } from '@/lib/error/api';
+import { useQueryClient } from '@tanstack/react-query';
 
 export default function Delete({ postId }: { postId: number }) {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isPending, setIsPending] = useState(false);
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   const handleDelete = async () => {
+    if (isPending) return; // 이미 삭제 중일 때 중복 클릭 방지
+    setIsPending(true);
     try {
+      // 게시글 Next.js fetch cache 초기화
       await deletePostAction(postId);
+      // (mypage 내 작성글/내 댓글  ) ReactQuery cache 초기화
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['myPage', 'posts'] }),
+        queryClient.invalidateQueries({ queryKey: ['myPage', 'comments'] }),
+      ]);
+
+      setIsModalOpen(false);
+
       router.replace('/');
       router.refresh();
     } catch (error) {
       alert(getErrorMessage(error, '글 삭제에 실패하였습니다.'));
+    } finally {
+      setIsPending(false);
     }
   };
 
@@ -27,6 +43,7 @@ export default function Delete({ postId }: { postId: number }) {
         onClick={() => {
           setIsModalOpen(true);
         }}
+        disabled={isPending}
       >
         삭제
       </Button>

--- a/components/posts/write/hooks/usePostSubmit.ts
+++ b/components/posts/write/hooks/usePostSubmit.ts
@@ -4,6 +4,7 @@ import {
   createPostAction,
   updatePostAction,
 } from '@/actions/post/post.actions';
+import { useQueryClient } from '@tanstack/react-query';
 
 type SubmitPostParams = {
   mode: 'create' | 'edit';
@@ -20,6 +21,16 @@ export function usePostSubmit({ clearMedia }: UsePostSubmitOptions) {
   const router = useRouter();
   const [isPending, setIsPending] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
+  const queryClient = useQueryClient();
+
+  const syncCachesAndNavigate = async (targetPostId: number | string) => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['myPage', 'posts'] }),
+      queryClient.invalidateQueries({ queryKey: ['myPage', 'comments'] }),
+    ]);
+    router.refresh();
+    router.push(`/posts/${targetPostId}`);
+  };
 
   const submitPost = async ({
     mode,
@@ -27,42 +38,45 @@ export function usePostSubmit({ clearMedia }: UsePostSubmitOptions) {
     formData,
     category,
   }: SubmitPostParams) => {
+    setIsPending(true);
+    setIsSuccess(false);
+
     if (mode === 'create') {
       try {
-        setIsPending(true);
         const response = await createPostAction(formData, category);
+        if (response.code !== 201 || !response.data?.postId) {
+          throw new Error('createPostAction failed');
+        }
         clearMedia();
         setIsSuccess(true);
-        if (response.code === 201 && response.data?.postId) {
-          router.refresh();
-          router.push(`/posts/${response.data.postId}`);
-        }
+        await syncCachesAndNavigate(response.data.postId);
       } catch (error) {
-        setIsPending(false);
         setIsSuccess(false);
         alert('글 작성 실패!');
         throw error;
+      } finally {
+        setIsPending(false);
       }
       return;
     }
 
     if (!postId) {
+      setIsPending(false);
       alert('글 ID가 없습니다.');
       return;
     }
 
     try {
-      setIsPending(true);
       await updatePostAction(postId, formData);
       clearMedia();
       setIsSuccess(true);
-      router.refresh();
-      router.push(`/posts/${postId}`);
+      await syncCachesAndNavigate(postId);
     } catch (error) {
-      setIsPending(false);
       setIsSuccess(false);
       alert('글 수정 실패!');
       throw error;
+    } finally {
+      setIsPending(false);
     }
   };
 


### PR DESCRIPTION

## #️⃣연관된 이슈

> #98 

  <br/>

## ✔️PR Checklist

- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

<br/>

## 🔎 작업 내용
- 게시글 생성/수정/삭제처럼 데이터가 바뀌는 작업 이후에는, 서버 캐시(Next.js)와 클라이언트 캐시(React Query)를 함께 갱신해 화면 간 데이터 정합성을 유지하도록 흐름을 통일함. 구현 측면에서는 생성/수정 후처리를 공통 함수로 묶어 마이페이지 관련 쿼리(myPage.posts, myPage.comments)를 무효화한 뒤 라우팅하도록 정리했고,

- 삭제 경로에도 동일한 React Query 무효화를 적용했으며, 서버 액션(deletePostAction)에서 revalidateTag/revalidatePath로 서버 캐시 갱신 범위가 명시되어있음