### PR TITLE
[REFACTOR] 게시글 상세 이미지 렌더링을 Next/Image 기반으로 개선

### DIFF
--- a/components/posts/detail/contents/PostContent.tsx
+++ b/components/posts/detail/contents/PostContent.tsx
@@ -1,14 +1,34 @@
 'use client';
 
+import Image from 'next/image';
 import DOMPurify from 'dompurify';
 import { useMemo } from 'react';
+import parse, {
+  attributesToProps,
+  domToReact,
+  type DOMNode,
+  type HTMLReactParserOptions,
+} from 'html-react-parser';
+import type { Element } from 'domhandler';
+
+const DEFAULT_IMAGE_ALT = 'post image';
+
+function getDimensionValue(value: unknown): number | null {
+  if (typeof value !== 'string') return null;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function normalizeMediaSrc(src: string): string {
+  return src.replace(/\\/g, '/');
+}
 
 // DOMPurify 사용 => html 정제 => XSS 공격으로부터 보호
 export default function PostContent({ html }: { html: string }) {
-  const sanitizedHTML = useMemo(() => {
+  const parsedContent = useMemo(() => {
     if (typeof window === 'undefined') return '';
 
-    return DOMPurify.sanitize(html, {
+    const sanitizedHtml = DOMPurify.sanitize(html, {
       ADD_TAGS: ['iframe', 'video', 'audio', 'source'], // 기본에 없는 태그만 추가
       ADD_ATTR: [
         'allow',
@@ -19,14 +39,74 @@ export default function PostContent({ html }: { html: string }) {
         'loop',
         'muted',
         'preload',
+        'width',
+        'height',
       ], // 미디어 관련 속성 추가
     });
+
+    const options: HTMLReactParserOptions = {
+      replace: (node) => {
+        if (node.type !== 'tag') return undefined;
+        const el = node as Element;
+
+        if (el.name === 'img') {
+          const props = attributesToProps(el.attribs);
+          const src = typeof props.src === 'string' ? props.src : '';
+          if (!src) return null;
+          const normalizedSrc = normalizeMediaSrc(src);
+
+          const width = getDimensionValue(props.width);
+          const height = getDimensionValue(props.height);
+
+          // width/height가 없을 때는 Next/Image 요구사항 때문에 기본 img로 fallback
+          if (!width || !height) {
+            return (
+              <img
+                {...props}
+                src={normalizedSrc}
+                alt={
+                  typeof props.alt === 'string' ? props.alt : DEFAULT_IMAGE_ALT
+                }
+                loading="lazy"
+                decoding="async"
+              />
+            );
+          }
+
+          return (
+            <Image
+              src={normalizedSrc}
+              alt={
+                typeof props.alt === 'string' ? props.alt : DEFAULT_IMAGE_ALT
+              }
+              // CLS(레이아웃 점프) 감소 목적으로 width, height 사용
+              width={width}
+              height={height}
+              loading="lazy"
+              className={
+                typeof props.className === 'string'
+                  ? props.className
+                  : undefined
+              }
+              sizes="(max-width: 768px) 100vw, 1002px"
+            />
+          );
+        }
+
+        if (el.name === 'video') {
+          return (
+            <video {...attributesToProps(el.attribs)} preload="metadata">
+              {domToReact(el.children as DOMNode[], options)}
+            </video>
+          );
+        }
+
+        return undefined;
+      },
+    };
+
+    return parse(sanitizedHtml, options);
   }, [html]);
 
-  return (
-    <div
-      className="prose prose-slate max-w-none"
-      dangerouslySetInnerHTML={{ __html: sanitizedHTML }}
-    />
-  );
+  return <div className="prose prose-slate max-w-none">{parsedContent}</div>;
 }

--- a/components/posts/detail/contents/PostMeta.tsx
+++ b/components/posts/detail/contents/PostMeta.tsx
@@ -11,7 +11,7 @@ export default async function PostMeta({ postId }: { postId: number }) {
   }
 
   const post = postDetailResponse.data;
-
+  console.log('post=====================', post);
   // placeholder를 실제 이미지 URL로 교체
   const displayContent = replacePlaceholdersWithUrls(
     post.content,

--- a/components/posts/write/utils/editorPasteHandler.ts
+++ b/components/posts/write/utils/editorPasteHandler.ts
@@ -1,4 +1,5 @@
 import type { Editor } from '@tiptap/react';
+import { getImageDimensions } from './mediaDimensions';
 
 // ---------------------------------------------------------------------------
 // 타입
@@ -182,16 +183,19 @@ export function createPasteHandler(options: PasteHandlerOptions) {
               type: file.type,
               lastModified: file.lastModified,
             });
-            return onMediaUpload(file).then((insertUrl) => ({
-              insertUrl,
-              isVideo,
-              dataFilename: safeName,
-            }));
+            return Promise.all([onMediaUpload(file), getImageDimensions(file)]).then(
+              ([insertUrl, imageDimensions]) => ({
+                insertUrl,
+                isVideo,
+                dataFilename: safeName,
+                imageDimensions,
+              }),
+            );
           }),
       ),
     )
       .then((results) => {
-        results.forEach(({ insertUrl, isVideo, dataFilename }) => {
+        results.forEach(({ insertUrl, isVideo, dataFilename, imageDimensions }) => {
           editorRef.current
             ?.chain()
             .focus()
@@ -210,6 +214,12 @@ export function createPasteHandler(options: PasteHandlerOptions) {
                     attrs: {
                       src: insertUrl,
                       ...(dataFilename && { dataFilename }),
+                      ...(imageDimensions?.width
+                        ? { width: imageDimensions.width }
+                        : {}),
+                      ...(imageDimensions?.height
+                        ? { height: imageDimensions.height }
+                        : {}),
                     },
                   },
             )

--- a/components/posts/write/utils/mediaDimensions.ts
+++ b/components/posts/write/utils/mediaDimensions.ts
@@ -1,0 +1,39 @@
+export type ImageDimensions = {
+  width: number;
+  height: number;
+};
+
+function isFiniteDimension(value: number): boolean {
+  return Number.isFinite(value) && value > 0;
+}
+
+export function getImageDimensions(file: File): Promise<ImageDimensions | null> {
+  if (!file.type.startsWith('image/')) {
+    return Promise.resolve(null);
+  }
+
+  return new Promise((resolve) => {
+    const objectUrl = URL.createObjectURL(file);
+    const img = new Image();
+
+    img.onload = () => {
+      const width = img.naturalWidth;
+      const height = img.naturalHeight;
+      URL.revokeObjectURL(objectUrl);
+
+      if (isFiniteDimension(width) && isFiniteDimension(height)) {
+        resolve({ width, height });
+        return;
+      }
+
+      resolve(null);
+    };
+
+    img.onerror = () => {
+      URL.revokeObjectURL(objectUrl);
+      resolve(null);
+    };
+
+    img.src = objectUrl;
+  });
+}

--- a/components/tiptap/tiptap-node/image-node/image-extension.ts
+++ b/components/tiptap/tiptap-node/image-node/image-extension.ts
@@ -8,6 +8,28 @@ export const Image = BaseImage.extend({
   addAttributes() {
     return {
       ...(this.parent?.() ?? {}),
+      width: {
+        default: null,
+        parseHTML: (element) => {
+          const value = element.getAttribute('width');
+          if (!value) return null;
+          const parsed = Number.parseInt(value, 10);
+          return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+        },
+        renderHTML: (attributes) =>
+          attributes.width ? { width: String(attributes.width) } : {},
+      },
+      height: {
+        default: null,
+        parseHTML: (element) => {
+          const value = element.getAttribute('height');
+          if (!value) return null;
+          const parsed = Number.parseInt(value, 10);
+          return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+        },
+        renderHTML: (attributes) =>
+          attributes.height ? { height: String(attributes.height) } : {},
+      },
       // 처음 수정되는 대상에 data-media-id 추가 -> new 미디어와 구분짓기 위함
       dataMediaId: {
         default: null,

--- a/components/tiptap/tiptap-node/image-upload-node/image-upload-node.tsx
+++ b/components/tiptap/tiptap-node/image-upload-node/image-upload-node.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/tiptap/tiptap-ui-primitive/button"
 import { CloseIcon } from "@/components/tiptap/tiptap-icons/close-icon"
 import "@/components/tiptap/tiptap-node/image-upload-node/image-upload-node.scss"
 import { focusNextNode, isValidPosition } from "@/lib/tiptap-utils"
+import { getImageDimensions } from "@/components/posts/write/utils/mediaDimensions"
 
 export interface FileItem {
   /**
@@ -457,21 +458,27 @@ export const ImageUploadNode: React.FC<NodeViewProps> = (props) => {
       const pos = props.getPos()
 
       if (isValidPosition(pos)) {
-        const imageNodes = urls.map((url, index) => {
-          const filename =
-            files[index]?.name.replace(/\.[^/.]+$/, "") || "unknown"
-          const fullName = files[index]?.name ?? undefined
-          return {
-            type: extension.options.type,
-            attrs: {
-              ...extension.options,
-              src: url,
-              alt: filename,
-              title: filename,
-              ...(fullName && { dataFilename: fullName }),
-            },
-          }
-        })
+        const imageNodes = await Promise.all(
+          urls.map(async (url, index) => {
+            const file = files[index]
+            const filename = file?.name.replace(/\.[^/.]+$/, "") || "unknown"
+            const fullName = file?.name ?? undefined
+            const dims = file ? await getImageDimensions(file) : null
+
+            return {
+              type: extension.options.type,
+              attrs: {
+                ...extension.options,
+                src: url,
+                alt: filename,
+                title: filename,
+                ...(fullName && { dataFilename: fullName }),
+                ...(dims?.width ? { width: dims.width } : {}),
+                ...(dims?.height ? { height: dims.height } : {}),
+              },
+            }
+          })
+        )
 
         props.editor
           .chain()

--- a/components/tiptap/tiptap-templates/simple/simple-editor.tsx
+++ b/components/tiptap/tiptap-templates/simple/simple-editor.tsx
@@ -81,6 +81,7 @@ import { useCursorVisibility } from '@/hooks/tiptap/use-cursor-visibility';
 // --- Lib ---
 import { MAX_FILE_SIZE } from '@/lib/tiptap-utils';
 import { createPasteHandler } from '@/components/posts/write/utils/editorPasteHandler';
+import { getImageDimensions } from '@/components/posts/write/utils/mediaDimensions';
 
 // --- Styles ---
 import '@/components/tiptap/tiptap-templates/simple/simple-editor.scss';
@@ -274,29 +275,40 @@ export function SimpleEditor({
         ],
         onPaste: (currentEditor, files) => {
           Promise.all(
-            files.map((file) => {
+            files.map(async (file) => {
               const isVideo = file.type.startsWith('video/');
-              return onMediaUpload(file).then((url) => {
-                currentEditor
-                  .chain()
-                  .focus()
-                  .insertContent(
-                    isVideo
-                      ? {
-                          type: 'video',
-                          attrs: {
-                            src: url,
-                            controls: true,
-                            dataFilename: file.name,
-                          },
-                        }
-                      : {
-                          type: 'image',
-                          attrs: { src: url, dataFilename: file.name },
+              const imageDimensions = isVideo
+                ? null
+                : await getImageDimensions(file);
+              const url = await onMediaUpload(file);
+              currentEditor
+                .chain()
+                .focus()
+                .insertContent(
+                  isVideo
+                    ? {
+                        type: 'video',
+                        attrs: {
+                          src: url,
+                          controls: true,
+                          dataFilename: file.name,
                         },
-                  )
-                  .run();
-              });
+                      }
+                    : {
+                        type: 'image',
+                        attrs: {
+                          src: url,
+                          dataFilename: file.name,
+                          ...(imageDimensions?.width
+                            ? { width: imageDimensions.width }
+                            : {}),
+                          ...(imageDimensions?.height
+                            ? { height: imageDimensions.height }
+                            : {}),
+                        },
+                      },
+                )
+                .run();
             }),
           ).catch((err) => {
             console.error('Paste upload failed:', err);
@@ -305,14 +317,27 @@ export function SimpleEditor({
         },
         onDrop: (currentEditor, files, pos) => {
           Promise.all(
-            files.map((file) => {
+            files.map(async (file) => {
               const isVideo = file.type.startsWith('video/');
-              return onMediaUpload(file).then((url) => ({
+              const imageDimensions = isVideo
+                ? null
+                : await getImageDimensions(file);
+              const url = await onMediaUpload(file);
+              return {
                 type: isVideo ? 'video' : 'image',
                 attrs: isVideo
                   ? { src: url, controls: true, dataFilename: file.name }
-                  : { src: url, dataFilename: file.name },
-              }));
+                  : {
+                      src: url,
+                      dataFilename: file.name,
+                      ...(imageDimensions?.width
+                        ? { width: imageDimensions.width }
+                        : {}),
+                      ...(imageDimensions?.height
+                        ? { height: imageDimensions.height }
+                        : {}),
+                    },
+              };
             }),
           )
             .then((nodes) => {

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,20 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   /* config options here */
   reactStrictMode: false,
+  images: {
+    dangerouslyAllowLocalIP: process.env.NODE_ENV !== 'production',
+    remotePatterns: [
+      {
+        protocol: 'http',
+        hostname: 'localhost',
+        port: '8080',
+      },
+      {
+        protocol: 'https',
+        hostname: 'api.drdr.kr',
+      },
+    ],
+  },
   experimental: {
     serverActions: {
       bodySizeLimit: '100mb',

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@tiptap/react": "^3.17.0",
         "@tiptap/starter-kit": "^3.17.0",
         "dompurify": "^3.3.1",
+        "html-react-parser": "^6.0.1",
         "lodash.throttle": "^4.1.1",
         "next": "16.1.1",
         "react": "19.2.3",
@@ -4468,6 +4469,67 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-3.0.0.tgz",
+      "integrity": "sha512-x+9D6nkC8tdXOQUS32egtZpZFLP90+HBZmWjuT920srbJvD/zPgFB9t4k3pEhlw5BQrXStQtRc1Y1zuriXk+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
+      "integrity": "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/domhandler": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-6.0.1.tgz",
+      "integrity": "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
     "node_modules/dompurify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
@@ -4475,6 +4537,24 @@
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-4.0.2.tgz",
+      "integrity": "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^3.0.0",
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dunder-proto": {
@@ -5658,6 +5738,87 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-dom-parser": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-7.0.1.tgz",
+      "integrity": "sha512-loRBDTCY/05/jAC63J1X9ID+xjRucmpLkIcQO0IRbOubBo5ucnpUpyXXob9UMXOskMZlu7KPsDP/2KOMelzJNA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/remarkablemark"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "6.0.1",
+        "htmlparser2": "12.0.0"
+      }
+    },
+    "node_modules/html-react-parser": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-6.0.1.tgz",
+      "integrity": "sha512-tIie2HSIk2Ct1tdupjd/DhBjskxN/NL5J4ncbUnk2smBr5UIfpPpitUo0imGfBM0BlOL7ac8RcqEwne1jXTcsQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/remarkablemark"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/html-react-parser"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "6.0.1",
+        "html-dom-parser": "7.0.1",
+        "react-property": "2.0.2",
+        "style-to-js": "1.1.21"
+      },
+      "peerDependencies": {
+        "@types/react": "0.14 || 15 || 16 || 17 || 18 || 19",
+        "react": "0.14 || 15 || 16 || 17 || 18 || 19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-12.0.0.tgz",
+      "integrity": "sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "domutils": "^4.0.2",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/http-parser-js": {
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
@@ -5713,6 +5874,12 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -7580,6 +7747,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
+      "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==",
+      "license": "MIT"
+    },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
@@ -8306,6 +8479,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/styled-jsx": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@tiptap/react": "^3.17.0",
     "@tiptap/starter-kit": "^3.17.0",
     "dompurify": "^3.3.1",
+    "html-react-parser": "^6.0.1",
     "lodash.throttle": "^4.1.1",
     "next": "16.1.1",
     "react": "19.2.3",


### PR DESCRIPTION


## #️⃣연관된 이슈

> #99 

  <br/>

## ✔️PR Checklist

- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

<br/>

## 작업 내용
- 게시글 상세 본문 렌더링을 dangerouslySetInnerHTML에서 HTML 파싱 기반으로 전환하고, img 태그를 Next/Image로 치환해 lazy loading/최적화 경로를 적용.
- 에디터 업로드/붙여넣기/드래그 앤 드롭 경로에서 이미지 width/height를 함께 저장하도록 보강해 CLS(레이아웃 점프) 가능성을 줄임.
- 로컬 개발 환경에서 localhost 이미지 최적화가 가능하도록 next.config 이미지 설정을 정리하고(remotePatterns, 개발환경 한정 dangerouslyAllowLocalIP), 운영 환경 안전성은 유지함.

## 한 줄 요약
- 상세 본문 img->Image 치환, 이미지 width/height 저장 강화, 개발환경 localhost 이미지 최적화 설정 추가